### PR TITLE
[fix] loginUser == null 오류

### DIFF
--- a/src/capstone/model/DonationPost.java
+++ b/src/capstone/model/DonationPost.java
@@ -17,6 +17,9 @@ public class DonationPost {
     private int raisedPoint;
     private String billImg;
 
+
+    private String virtualAccount;
+
     // 기본 생성자
     public DonationPost() {
     }
@@ -85,6 +88,14 @@ public class DonationPost {
 
     public void setWriter(User writer) {
         this.writer = writer;
+    }
+
+    public void setVirtualAccount(String virtualAccount) {
+        this.virtualAccount = virtualAccount;
+    }
+
+    public String getVirtualAccount() {
+        return virtualAccount;
     }
 
     @Override

--- a/src/capstone/model/User.java
+++ b/src/capstone/model/User.java
@@ -73,4 +73,18 @@ public class User {
 
     public String getTier() { return String.valueOf(tier); }
     public void setTier(Tier tier) { this.tier = tier; }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        User user = (User) obj;
+        return userId != null && userId.equals(user.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return userId != null ? userId.hashCode() : 0;
+    }
+
 }

--- a/src/capstone/service/DonationPostService.java
+++ b/src/capstone/service/DonationPostService.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 
 public class DonationPostService {
     private final List<DonationPost> posts = new ArrayList<>();
@@ -23,7 +24,20 @@ public class DonationPostService {
 
     public void create(User writer, String donationImg, int goalPoint, LocalDate endAt, String title, String content) {
         DonationPost post = new DonationPost(writer, donationImg, goalPoint, endAt, title, content);
+        String virtualAccount = generateVirtualAccount(); // 가상계좌 생성
+        post.setVirtualAccount(virtualAccount); // 가상계좌 설정
         posts.add(post);
+    }
+
+    // 랜덤 가상계좌 생성
+    private String generateVirtualAccount() {
+        Random random = new Random();
+        StringBuilder sb = new StringBuilder();
+        sb.append("VA-"); // prefix (예: 가상계좌의 의미)
+        for (int i = 0; i < 12; i++) {
+            sb.append(random.nextInt(10)); // 0~9 숫자 12자리
+        }
+        return sb.toString();
     }
 
     public List<DonationPost> getAll() {

--- a/src/capstone/view/donation/DonationPostDetailView.java
+++ b/src/capstone/view/donation/DonationPostDetailView.java
@@ -33,7 +33,7 @@ public class DonationPostDetailView extends JFrame {
         panel.add(new JLabel("목표 금액: " + post.getGoalPoint() + "P"));
         panel.add(new JLabel("마감일: " + (post.getEndAt() != null ? post.getEndAt().toString() : "없음")));
 
-        if (loginUser != null && post.getWriter() != null && loginUser.getUserId().equals(post.getWriter().getUserId())) {
+        if (post.getWriter() != null && post.getWriter().equals(loginUser)) {
             JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
 
             JButton editBtn = new JButton("수정");

--- a/src/capstone/view/donation/DonationPostDetailView.java
+++ b/src/capstone/view/donation/DonationPostDetailView.java
@@ -34,6 +34,9 @@ public class DonationPostDetailView extends JFrame {
         panel.add(new JLabel("마감일: " + (post.getEndAt() != null ? post.getEndAt().toString() : "없음")));
 
         if (post.getWriter() != null && post.getWriter().equals(loginUser)) {
+//            panel.add(Box.createVerticalStrut(10)); // 여백
+            panel.add(new JLabel("가상계좌: " + (post.getVirtualAccount() != null ? post.getVirtualAccount() : "없음")));
+
             JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
 
             JButton editBtn = new JButton("수정");

--- a/src/capstone/view/donation/DonationPostWriteView.java
+++ b/src/capstone/view/donation/DonationPostWriteView.java
@@ -9,7 +9,6 @@ import java.time.LocalDate;
 
 public class DonationPostWriteView extends JFrame {
     public DonationPostWriteView(User user, DonationPostController controller) {
-        System.out.println("DonationPostWriteView: "+user);
 
         setTitle("기부글 작성");
         setSize(500, 400);

--- a/src/capstone/view/main/DonationPostListPanel.java
+++ b/src/capstone/view/main/DonationPostListPanel.java
@@ -14,8 +14,10 @@ public class DonationPostListPanel extends JPanel {
     private final DefaultListModel<DonationPost> listModel = new DefaultListModel<>();
     private final JList<DonationPost> postList = new JList<>(listModel);
     private final DonationPostController controller;
+    private final User loginUser;
 
     public DonationPostListPanel(User loginUser, DonationPostController controller) {
+        this.loginUser = loginUser;
         this.controller = controller;
         setLayout(new BorderLayout());
 
@@ -33,10 +35,17 @@ public class DonationPostListPanel extends JPanel {
 
         // 더블 클릭 시 상세보기
         postList.addMouseListener(new MouseAdapter() {
+            @Override
             public void mouseClicked(MouseEvent e) {
-                if (e.getClickCount() == 2 && postList.getSelectedValue() != null) {
-                    DonationPost selected = postList.getSelectedValue();
-                    new DonationPostDetailView(selected, loginUser, controller, () -> refreshList()).setVisible(true);
+                if (e.getClickCount() == 2) {
+                    DonationPost post = postList.getSelectedValue();
+
+                    new DonationPostDetailView(
+                            post,
+                            loginUser,
+                            controller,
+                            DonationPostListPanel.this::refreshList
+                    ).setVisible(true);
                 }
             }
         });
@@ -51,5 +60,4 @@ public class DonationPostListPanel extends JPanel {
             listModel.addElement(post);
         }
     }
-
 }

--- a/src/capstone/view/main/MainView.java
+++ b/src/capstone/view/main/MainView.java
@@ -50,10 +50,17 @@ public class MainView extends JFrame {
         loginItem.addActionListener(e -> {
             new LoginView(userController, user -> {
                 this.loginUser = user;
-                setTitle("메인 메뉴(" + user.getUserId()+")");
+                setTitle("메인 메뉴(" + user.getUserId() + ")");
                 sessionMenu.setText(user.getUserId());
-                JOptionPane.showMessageDialog(this, "로그인 성공");
                 updateMenuAccess();
+
+                donationPostListPanel = new DonationPostListPanel(this.loginUser, donationPostController);
+                centerPanel.removeAll();
+                centerPanel.add(donationPostListPanel, BorderLayout.CENTER);
+                centerPanel.revalidate();
+                centerPanel.repaint();
+
+                JOptionPane.showMessageDialog(this, "로그인 성공");
             }).setVisible(true);
         });
 
@@ -66,8 +73,11 @@ public class MainView extends JFrame {
                 this.loginUser = null;
                 setTitle("메인 메뉴 (비로그인)");
                 sessionMenu.setText("로그인/회원가입");
-                JOptionPane.showMessageDialog(this, "로그아웃 되었습니다.");
                 updateMenuAccess();
+                centerPanel.removeAll(); // ✅ 로그아웃 시 화면 초기화
+                centerPanel.revalidate();
+                centerPanel.repaint();
+                JOptionPane.showMessageDialog(this, "로그아웃 되었습니다.");
             } else {
                 JOptionPane.showMessageDialog(this, "현재 로그인 상태가 아닙니다.");
             }
@@ -133,7 +143,8 @@ public class MainView extends JFrame {
         detailMenu.add(allPostsItem);
 
         allPostsItem.addActionListener(e -> {
-            swapCenterPanel(new DonationPostListPanel(this.loginUser, donationPostController));
+            DonationPostListPanel panel = new DonationPostListPanel(this.loginUser, donationPostController);
+            swapCenterPanel(panel);
         });
 
         menuBar.add(sessionMenu);
@@ -145,9 +156,7 @@ public class MainView extends JFrame {
         setJMenuBar(menuBar);
 
         // 메인 패널 설정
-        donationPostListPanel = new DonationPostListPanel(this.loginUser, donationPostController);
         centerPanel = new JPanel(new BorderLayout());
-        centerPanel.add(donationPostListPanel, BorderLayout.CENTER);
         add(centerPanel, BorderLayout.CENTER);
         updateMenuAccess();
     }


### PR DESCRIPTION
### 🐞 문제 현상
DonationPostListPanel에서 기부글 더블클릭 시, DonationPostDetailView에 전달되는 loginUser가 null이었음
그 결과 본인이 작성한 기부글임에도 수정/삭제 버튼이 안 보이거나 NullPointerException 발생

### 🔍 원인 분석
MainView에서 로그인 이전에 DonationPostListPanel을 먼저 생성했기 때문에 해당 패널의 loginUser가 null 상태로 유지됨
이후 로그인 성공 시 loginUser가 설정되지만 이미 생성된 패널에는 반영되지 않음 (setter 제거로 해결 불가능)

### ✅ 해결 방법
로그인 전에는 DonationPostListPanel을 생성하지 않고 기다림
로그인 성공 시점에만 loginUser가 있는 상태로 패널을 생성
패널 내부에서는 생성자에서 전달된 loginUser를 그대로 사용

### 🧪 확인 결과
로그인 후 새로 생성된 패널에서는 loginUser가 정확히 주입됨
기부글 더블클릭 시 수정/삭제 버튼 정상 표시
더 이상 NPE 발생하지 않음

### 📝 비고
구조상 setter 없이도 loginUser 상태를 보장할 수 있어서 더 단순해짐
이 구조를 다른 상태 의존 패널에도 재활용할 수 있음

---
### 기부글 기능 구현
- 기부글 작성 시 해당 글의 가상계좌를 랜덤 생성 및 설정